### PR TITLE
Update changelog and deps

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-subiquity (0.0.1) UNRELEASED; urgency=medium
+subiquity (0.0.1-0ubuntu1) wily; urgency=medium
 
   * Initial build.
 

--- a/debian/control
+++ b/debian/control
@@ -34,7 +34,7 @@ Depends: bzr
          qemu-utils,
          shim,
          shim-signed,
-         simplstreams,
+         simplestreams,
          syslinux-common,
          ubuntu-cloudimage-keyring,
          ${python3:Depends},

--- a/debian/control
+++ b/debian/control
@@ -6,20 +6,9 @@ Build-Depends: bzr,
                debhelper (>= 9),
                dh-python,
                git,
-               pep8,
-               pyflakes,
                python3-all,
-               python3-coverage,
-               python3-flake8,
-               python3-jinja2,
-               python3-netifaces,
-               python3-nose,
-               python3-pyudev,
                python3-setuptools,
-               python3-urwid,
-               python3-yaml,
-               python3-tornado,
-               ubuntu-cloudimage-keyring
+               python3-yaml
 Standards-Version: 3.9.5
 Homepage: https://github.com/CanonicalLtd/subiquity
 X-Python3-Version: >= 3.3
@@ -27,22 +16,27 @@ Vcs-Browser: https://github.com/CanonicalLtd/subiquity
 Vcs-Git: https://github.com/CanonicalLtd/subiquity.git
 
 Package: subiquity
-Architecture: all
+Architecture: amd64
 Depends: bzr
          ${misc:Depends},
+         extlinux,
+         gdisk,
          git,
+         grub-efi-amd64-signed,
+         grub2-common,
+         kpartx,
+         parted,
+         probert,
          python3-all,
-         python3-coverage,
-         python3-flake8,
-         python3-jinja2,
-         python3-netifaces,
-         python3-nose,
-         python3-pyudev,
-         python3-setuptools,
+         python3-tornado,
          python3-urwid,
          python3-yaml,
+         qemu-utils,
+         shim,
+         shim-signed,
+         simplstreams,
+         syslinux-common,
          ubuntu-cloudimage-keyring,
-         python3-tornado,
          ${python3:Depends},
          ${python:Depends}
 Description: Ubuntu Server Installer

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: bzr,
                debhelper (>= 9),
                dh-python,
                git,
-               python3-all,
+               python3,
                python3-setuptools,
                python3-yaml
 Standards-Version: 3.9.5

--- a/debian/docs
+++ b/debian/docs
@@ -1,1 +1,2 @@
 README.md
+examples


### PR DESCRIPTION
Couple of updates:
- add the 0ubuntu1 version string
- Drop source level deps (nose, lint, pep8, etc)
- Add in runtime deps of subiquity-geninstaller
- Package up examples dir (useful for --machine param to subiquity)
