### PR TITLE
Add cloud-image-utils dep for geninstaller

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Package: subiquity
 Architecture: amd64
 Depends: bzr
          ${misc:Depends},
+         cloud-image-utils,
          extlinux,
          gdisk,
          git,


### PR DESCRIPTION
geninstaller uses mount-image-callback via maas2roottar
so we need an installtime dep.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
