### PR TITLE
Add curtin deb and bump release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+subiquity (0.0.1-0ubuntu2) wily; urgency=medium
+
+  * Add curtin to package deps
+  * Find curtin and install source dynamically (Closes: #64)
+
+ -- Ryan Harper <ryan.harper@canonical.com>  Wed, 07 Oct 2015 08:49:39 -0500
+
 subiquity (0.0.1-0ubuntu1) wily; urgency=medium
 
   * Initial build.

--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,7 @@ Architecture: amd64
 Depends: bzr
          ${misc:Depends},
          cloud-image-utils,
+         curtin,
          extlinux,
          gdisk,
          git,


### PR DESCRIPTION
Subiquity depends on the curtin package
Latest code in master now searches for curtin and install source.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
