### PR TITLE
Break out geninstaller/runinstaller into separate subpackage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+subiquity (0.0.1-0ubuntu3) wily; urgency=medium
+
+  * Break subiquity-{gen|run}installer into -tools package (Closes: #80)
+
+ -- Ryan Harper <ryan.harper@canonical.com>  Tue, 20 Oct 2015 17:02:47 -0500
+
 subiquity (0.0.1-0ubuntu2) wily; urgency=medium
 
   * Add curtin to package deps

--- a/debian/control
+++ b/debian/control
@@ -17,10 +17,22 @@ Vcs-Git: https://github.com/CanonicalLtd/subiquity.git
 
 Package: subiquity
 Architecture: amd64
+Depends: curtin,
+         probert,
+         python3-tornado,
+         python3-urwid,
+         python3-yaml,
+         ${misc:Depends},
+         ${python3:Depends}
+Description: Ubuntu Server Installer
+ This package provides the installer routines for bootstrapping a system
+ with the Subiquity the server installer UI.
+
+Package: subiquity-tools
+Architecture: amd64
 Depends: bzr
          ${misc:Depends},
          cloud-image-utils,
-         curtin,
          extlinux,
          gdisk,
          git,
@@ -28,14 +40,11 @@ Depends: bzr
          grub2-common,
          kpartx,
          parted,
-         probert,
-         python3-tornado,
-         python3-urwid,
-         python3-yaml,
          qemu-utils,
          shim,
          shim-signed,
          simplestreams,
+         subiquity,
          syslinux-common,
          ubuntu-cloudimage-keyring,
          ${python3:Depends}

--- a/debian/subiquity-tools.install
+++ b/debian/subiquity-tools.install
@@ -1,0 +1,1 @@
+installer                              usr/share/subiquity/

--- a/debian/subiquity-tools.links
+++ b/debian/subiquity-tools.links
@@ -1,0 +1,2 @@
+/usr/share/subiquity/installer/geninstaller   /usr/bin/subiquity-geninstaller
+/usr/share/subiquity/installer/runinstaller   /usr/bin/subiquity-runinstaller

--- a/debian/subiquity.install
+++ b/debian/subiquity.install
@@ -1,3 +1,1 @@
-bin/curtin_wrap.sh                     usr/share/subiquity/bin
 bin/subiquity-tui                      usr/share/subiquity
-installer                              usr/share/subiquity/

--- a/debian/subiquity.links
+++ b/debian/subiquity.links
@@ -1,3 +1,1 @@
 /usr/share/subiquity/subiquity-tui            /usr/bin/subiquity
-/usr/share/subiquity/installer/geninstaller   /usr/bin/subiquity-geninstaller
-/usr/share/subiquity/installer/runinstaller   /usr/bin/subiquity-runinstaller


### PR DESCRIPTION
The tui doesn't need to depend on all of the packages required
for building the installer image.  Users won't need to install
as many packages before trying subiquity out.

Signed-off-by: Ryan Harper ryan.harper@canonical.com
